### PR TITLE
Support building httplib.h on OpenVMS x86 systems

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -218,7 +218,9 @@ using socket_t = SOCKET;
 #include <csignal>
 #include <pthread.h>
 #include <sys/mman.h>
-#include <sys/select.h>
+#ifndef __VMS
+  #include <sys/select.h>
+#endif
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>


### PR DESCRIPTION
Modify for OpenVMS x86 C++. Make tests on OpenVMS currently not supported due to no cmake support. Changes tested on x86 OpenVMS clang C++ and Fedora & GCC